### PR TITLE
Fix nested DelegatingLogger issue.

### DIFF
--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -30,7 +30,7 @@ module Alephant
     end
 
     def self.set_logger(value)
-      @@logger = Alephant::DelegatingLogger.new value if !@@logger.is_a?(DelegatingLogger)
+      @@logger ||= Alephant::DelegatingLogger.new value
     end
   end
 end

--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -30,7 +30,11 @@ module Alephant
     end
 
     def self.set_logger(value)
-      @@logger ||= Alephant::DelegatingLogger.new value
+      if value.is_a?(DelegatingLogger)
+        @@logger = value
+      else
+        @@logger = Alephant::DelegatingLogger.new value
+      end
     end
   end
 end

--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -29,11 +29,11 @@ module Alephant
       @@logger ||= Alephant::DelegatingLogger.new ::Logger.new(STDOUT)
     end
 
-    def self.set_logger(value)
-      if value.is_a?(DelegatingLogger)
-        @@logger = value
+    def self.set_logger(logger)
+      if logger.is_a?(DelegatingLogger)
+        @@logger = logger
       else
-        @@logger = Alephant::DelegatingLogger.new value
+        @@logger = Alephant::DelegatingLogger.new logger
       end
     end
   end

--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -30,7 +30,7 @@ module Alephant
     end
 
     def self.set_logger(value)
-      @@logger = Alephant::DelegatingLogger.new value
+      @@logger = Alephant::DelegatingLogger.new value if !@@logger.is_a?(DelegatingLogger)
     end
   end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Alephant::Logger do
+
+  after(:each) do
+    subject.class_variable_set(:@@logger, nil)
+  end
+
   describe ".get_logger" do
 
     context "no logger set" do


### PR DESCRIPTION
Ensures only one layer of DelegatingLogger is created. Currently if you run a renderer with logging, you end up with many nested loggers which slows performance and eventually crashes the renderer. It would be useful to us at Softwire if this could be merged soon.