### PR TITLE
[READY] Use factory and add `logger` instance method

### DIFF
--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -4,7 +4,7 @@ require "logger"
 
 module Alephant
   module Logger
-    @@logger = Alephant::LoggerFactory.create
+    @@logger = Alephant::LoggerFactory.create []
 
     def logger
       @@logger

--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -13,7 +13,5 @@ module Alephant
     def self.setup(*drivers)
       @@logger = Alephant::LoggerFactory.create(drivers.flatten)
     end
-
   end
 end
-

--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -1,33 +1,19 @@
-require 'alephant/logger/version'
-require 'logger'
+require "alephant/logger/version"
+require "alephant/logger_factory"
+require "logger"
 
 module Alephant
   module Logger
-    def self.create(drivers = [])
-      Logger.new drivers
+    @@logger = Alephant::LoggerFactory.create
+
+    def logger
+      @@logger
     end
 
-    class Logger
-      def initialize(drivers)
-        @drivers = drivers << ::Logger.new(STDOUT)
-      end
-
-      def method_missing(name, *args)
-        drivers.each do |driver|
-          driver.send(name, *args) if driver.respond_to? name
-        end
-      end
-
-      def respond_to?(name)
-        drivers.any? do |driver|
-          driver.respond_to?(name) || super
-        end
-      end
-
-      private
-
-      attr_reader :drivers
+    def self.setup(*drivers)
+      @@logger = Alephant::LoggerFactory.create(drivers.flatten)
     end
+
   end
 end
 

--- a/lib/alephant/logger/base.rb
+++ b/lib/alephant/logger/base.rb
@@ -1,0 +1,26 @@
+module Alephant
+  module Logger
+    class Base
+      def initialize(drivers)
+        @drivers = drivers << ::Logger.new(STDOUT)
+      end
+
+      def method_missing(name, *args)
+        drivers.each do |driver|
+          driver.send(name, *args) if driver.respond_to? name
+        end
+      end
+
+      def respond_to?(name)
+        drivers.any? do |driver|
+          driver.respond_to?(name) || super
+        end
+      end
+
+      private
+
+      attr_reader :drivers
+    end
+  end
+end
+

--- a/lib/alephant/logger/base.rb
+++ b/lib/alephant/logger/base.rb
@@ -23,4 +23,3 @@ module Alephant
     end
   end
 end
-

--- a/lib/alephant/logger_factory.rb
+++ b/lib/alephant/logger_factory.rb
@@ -2,10 +2,8 @@ require "alephant/logger/base"
 
 module Alephant
   module LoggerFactory
-
     def self.create(drivers = [])
       Alephant::Logger::Base.new drivers
     end
-
   end
 end

--- a/lib/alephant/logger_factory.rb
+++ b/lib/alephant/logger_factory.rb
@@ -1,0 +1,11 @@
+require "alephant/logger/base"
+
+module Alephant
+  module LoggerFactory
+
+    def self.create(drivers = [])
+      Alephant::Logger::Base.new drivers
+    end
+
+  end
+end

--- a/lib/alephant/logger_factory.rb
+++ b/lib/alephant/logger_factory.rb
@@ -2,7 +2,7 @@ require "alephant/logger/base"
 
 module Alephant
   module LoggerFactory
-    def self.create(drivers = [])
+    def self.create(drivers)
       Alephant::Logger::Base.new drivers
     end
   end

--- a/spec/logger_base_spec.rb
+++ b/spec/logger_base_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Alephant::Logger::Base do
+  describe "#info" do
+    context "no logger drivers given" do
+      subject { Alephant::Logger::Base.new [] }
+
+      specify do
+        expect_any_instance_of(::Logger).to receive(:info).with "msg"
+
+        subject.info "msg"
+      end
+    end
+
+    context "logger drivers given" do
+      subject { Alephant::Logger::Base.new [driver] }
+
+      let(:driver) { double }
+
+      it "responding drivers receive method calls" do
+        expect(driver).to receive(:metric).with("foo")
+
+        subject.metric("foo")
+      end
+
+      it "::Logger is always used" do
+        expect_any_instance_of(::Logger).to receive(:info).with "foo"
+
+        subject.info "foo"
+      end
+    end
+  end
+end

--- a/spec/logger_base_spec.rb
+++ b/spec/logger_base_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Alephant::Logger::Base do
   describe "#info" do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Alephant::Logger do
   describe ".setup" do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,41 +1,9 @@
 require 'spec_helper'
 
 describe Alephant::Logger do
-  describe ".create" do
+  describe ".setup" do
     specify do
-      expect(subject.create).to be_a Alephant::Logger::Logger
-    end
-  end
-end
-
-describe Alephant::Logger::Logger do
-  describe "#info" do
-    context "no logger drivers given" do
-      subject { Alephant::Logger::Logger.new [] }
-
-      specify do
-        expect_any_instance_of(::Logger).to receive(:info).with "msg"
-
-        subject.info "msg"
-      end
-    end
-
-    context "logger drivers given" do
-      subject { Alephant::Logger::Logger.new [driver] }
-
-      let(:driver) { double }
-
-      it "responding drivers receive method calls" do
-        expect(driver).to receive(:metric).with("foo")
-
-        subject.metric("foo")
-      end
-
-      it "::Logger is always used" do
-        expect_any_instance_of(::Logger).to receive(:info).with "foo"
-
-        subject.info "foo"
-      end
+      expect(subject.setup).to be_a Alephant::Logger::Base
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
-$: << File.join(File.dirname(__FILE__),"..", "lib")
+$LOAD_PATH << File.join(File.dirname(__FILE__), "..", "lib")
 
-require 'pry'
-require 'alephant/logger'
-
+require "pry"
+require "alephant/logger"


### PR DESCRIPTION
### Problem

There wasn't an easy way to use the gem after the major version bump, and all other gems using `include Alephant::Logger` would have issues.

### Solution

Move the creation logic into a separate namespace, and add an instance method `logger` that get's mixed into any class including it and uses the module level variable `@@logger` and whatever is currently in there. 

### Release

*Minor* - This release is more of a fix even though it breaks the underlying API so is deemed a minor release.