### PR TITLE
:write method (monkey patch)

### DIFF
--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -10,6 +10,10 @@ module Alephant
       @@logger
     end
 
+    def self.get_logger
+      @@logger
+    end
+
     def self.setup(*drivers)
       @@logger = Alephant::LoggerFactory.create(drivers.flatten)
     end

--- a/lib/alephant/logger/base.rb
+++ b/lib/alephant/logger/base.rb
@@ -5,6 +5,10 @@ module Alephant
         @drivers = drivers << ::Logger.new(STDOUT)
       end
 
+      def write(*args)
+        self.<< *args
+      end
+
       def method_missing(name, *args)
         drivers.each do |driver|
           driver.send(name, *args) if driver.respond_to? name


### PR DESCRIPTION
![waaaait_for_me](http://i.imgur.com/IH6JVv4.gif)

[Trello Card](https://trello.com/c/lEdqRpfI/200-add-monitoring-to-market-data-broker)
### Problem 

Add the [monkey-patch](https://github.com/BBC-News/market-data-broker/commit/98503d070d63c7976fe07eead28e7b5d791d3c1a#diff-ea411e7ce8813c53964a993d12616e14L29) officially to the gem. Logger needs to be able to accept `:write` method and call `<<`.