### PR TITLE
Updated README to match recent API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Or install it yourself as:
 $ gem install alephant-logger
 ```
 
+In addition to this, you may want to install one of the supported Alephant logger drivers:
+* [alephant-logger-statsd](https://github.com/BBC-News/alephant-logger-statsd)
+* [alephant-logger-cloudwatch](https://github.com/BBC-News/alephant-logger-cloudwatch)
+
 ## Usage
 
 ```rb
@@ -41,7 +45,7 @@ config = {
 statsd_driver     = Alephant::Logger::Statsd.new config
 cloudwatch_driver = Alephant::Logger::CloudWatch.new "my_namespace"
 
-logger = Alephant::Logger.create([statsd_driver, cloudwatch_driver])
+logger = Alephant::Logger.setup([statsd_driver, cloudwatch_driver])
 logger.increment "foo.bar"
 logger.metric(:name => "FooBar", :unit => "Count", :value => 1)
 ```

--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ logger.increment "foo.bar"
 logger.metric(:name => "FooBar", :unit => "Count", :value => 1)
 ```
 
-## Drivers
-
-You can consume an array of other gems to allow Alephant Logger to send custom metrics:
-
-1. [Statsd](https://github.com/BBC-News/alephant-logger-statsd#alephantloggerstatsd)
-
 ## Contributing
 
 1. [Fork it!](http://github.com/BBC-News/alephant-logger/fork)


### PR DESCRIPTION
1. `.create` doesn't exist any more, you need to call `.setup` instead.
2. It's not obvious that you need to install the drivers from a separate package now - I've added a note to the installation section highlighting that.