### PR TITLE
Use alephant-logger-json as default out to app.log

### DIFF
--- a/alephant-logger.gemspec
+++ b/alephant-logger.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "alephant-logger-json", "0.1"
+
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-nc"
   spec.add_development_dependency "guard"

--- a/lib/alephant/logger/base.rb
+++ b/lib/alephant/logger/base.rb
@@ -1,8 +1,14 @@
+require "alephant/logger/json"
+
 module Alephant
   module Logger
     class Base
       def initialize(drivers)
-        @drivers = drivers << Alephant::Logger::JSON.new "app.log"
+        @drivers = drivers
+
+        unless drivers.any? { |driver| driver.is_a? Alephant::Logger::JSON }
+          drivers << Alephant::Logger::JSON.new("app.log")
+        end
       end
 
       def write(*args)

--- a/lib/alephant/logger/base.rb
+++ b/lib/alephant/logger/base.rb
@@ -2,7 +2,7 @@ module Alephant
   module Logger
     class Base
       def initialize(drivers)
-        @drivers = drivers << ::Logger.new(STDOUT)
+        @drivers = drivers << Alephant::Logger::JSON.new "app.log"
       end
 
       def write(*args)

--- a/spec/logger_base_spec.rb
+++ b/spec/logger_base_spec.rb
@@ -1,14 +1,24 @@
 require "spec_helper"
 
+require "pry"
 describe Alephant::Logger::Base do
+  context "no Alephant::Logger::JSON driver given" do
+    it "defaults to include Alephant::Logger::JSON" do
+      allow(Alephant::Logger::JSON).to receive(:new) { @called = true }
+
+      described_class.new []
+      expect(@called).to be_truthy
+    end
+  end
+
   describe "#info" do
     context "no logger drivers given" do
       subject { Alephant::Logger::Base.new [] }
 
       specify do
-        expect_any_instance_of(::Logger).to receive(:info).with "msg"
+        expect_any_instance_of(Alephant::Logger::JSON).to receive(:info).with("event" => "Evented")
 
-        subject.info "msg"
+        subject.info("event" => "Evented")
       end
     end
 
@@ -23,10 +33,10 @@ describe Alephant::Logger::Base do
         subject.metric("foo")
       end
 
-      it "::Logger is always used" do
-        expect_any_instance_of(::Logger).to receive(:info).with "foo"
+      it "Alephant::Logger::JSON is always used" do
+        expect_any_instance_of(Alephant::Logger::JSON).to receive(:info).with("event" => "Evented")
 
-        subject.info "foo"
+        subject.info("event" => "Evented")
       end
     end
   end


### PR DESCRIPTION
![cattank](http://media.giphy.com/media/JIS3HjZexQJsk/giphy.gif)

## Problem

Defaults to standard Ruby Logger, despite structured logging being the new approach in Alephant.  It takes strings instead of hashes.

## Solution

If no `Alephant::Logger::JSON` driver is provided, add one by default which writes to `app.log` in the current working directory.

## Release

Major.