### PR TITLE
Ensure consumers explicitly bootstrap logger...

### DIFF
--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -4,8 +4,6 @@ require "logger"
 
 module Alephant
   module Logger
-    @@logger = Alephant::LoggerFactory.create []
-
     def logger
       @@logger
     end


### PR DESCRIPTION
![](http://media2.giphy.com/media/l41lVCaNfN7zjhFsc/giphy.gif)
*^ I've been saving this gif for ages. I wanted to ensure I use it on only the most epic of PRs*

## Problem

This allows us to avoid an issue where by the alephant-logger is automatically instantiated and subsequently causes the side effect of creating an `app.log` file (as well as a log file specified when the consumer explicitly calls the setup method)

## Solution

Require consumer to explicitly call setup method rather than do this for the consumer