### PR TITLE
Update version of json logger

### DIFF
--- a/alephant-logger.gemspec
+++ b/alephant-logger.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "alephant-logger-json", "0.1"
+  spec.add_runtime_dependency "alephant-logger-json", "~> 0.1.0"
 
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-nc"


### PR DESCRIPTION
## Problem

JSON logger version was capped at a specific version

## Solution

Utilise `~>` so it will cap until the next minor release