### PR TITLE
Setup logger if self.get_logger called before @@logger initialized.

### DIFF
--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -11,6 +11,8 @@ module Alephant
     end
 
     def self.get_logger
+      Alephant::Logger.setup unless defined? @@logger
+
       @@logger
     end
 

--- a/lib/alephant/logger.rb
+++ b/lib/alephant/logger.rb
@@ -5,19 +5,21 @@ require "logger"
 module Alephant
   module Logger
     def logger
-      Alephant::Logger.setup unless defined? @@logger
-
+      Logger.verify_logger_created
       @@logger
     end
 
     def self.get_logger
-      Alephant::Logger.setup unless defined? @@logger
-
+      verify_logger_created
       @@logger
     end
 
     def self.setup(*drivers)
       @@logger = Alephant::LoggerFactory.create(drivers.flatten)
+    end
+
+    def self.verify_logger_created
+      Alephant::Logger.setup unless defined? @@logger
     end
   end
 end


### PR DESCRIPTION
The aim of this is to ensure @@logger is initialized in cases where consumers call Logger.get_logger without first explicitly setting up the logger - for example in Newsbeat's BBC-content-services.

In this case we want any services using the BBC-content servies gem to be able to specify drivers themselves for the logger (so we can't call setup in the BCS itself), but we don't want them to break at the "get_logger" call in bbc-content-services is they don't explicitly set up the logger.
