### PR TITLE
Remove Guard

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,0 @@
-guard 'rspec' do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/.+\.rb$})
-  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
-  watch('spec/spec_helper.rb')                        { "spec" }
-end

--- a/alephant-logger.gemspec
+++ b/alephant-logger.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-nc"
-  spec.add_development_dependency "guard"
-  spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-remote"
   spec.add_development_dependency "pry-nav"

--- a/lib/alephant/logger/version.rb
+++ b/lib/alephant/logger/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Logger
-    VERSION = "3.1.3"
+    VERSION = "3.1.4"
   end
 end


### PR DESCRIPTION
It looks like the latest version of Guard requires Ruby greater than or equal to 2.2. JRuby is equivalent to 1.9. We could either fix to a lower version, but as it doesn't seem to be used, I have removed.

```
Gem::InstallError: ruby_dep requires Ruby version >= 2.2.5, ~> 2.2.
An error occurred while installing ruby_dep (1.5.0), and Bundler
cannot continue.
Make sure that `gem install ruby_dep -v '1.5.0'` succeeds before bundling.

In Gemfile:
  guard-rspec was resolved to 4.7.3, which depends on
    guard was resolved to 2.14.1, which depends on
      listen was resolved to 3.1.5, which depends on
        ruby_dep
```